### PR TITLE
enable to use a custom hostname for usage behind a proxy

### DIFF
--- a/src/Services/DefaultUrlService.js
+++ b/src/Services/DefaultUrlService.js
@@ -33,7 +33,7 @@ define([], function () {
 
     // constantes internes
     var protocol = (location && location.protocol && location.protocol.indexOf("https:") === 0 ? "https://" : "http://");
-    var hostname = "wxs.ign.fr";
+    var hostname = "__GP_CUSTOM_HOSTNAME__" in window ? window["__GP_CUSTOM_HOSTNAME__"] : "wxs.ign.fr";
     var keyname = "%KEY%";
     var url = protocol + hostname.concat("/", keyname);
 


### PR DESCRIPTION
Bonjour,

Certains de nos clients ne peuvent pas utiliser cette bibliothèque d'accès du fait de politiques de sécurité réseau très strictes au sein de leur entreprise, fonctionnant notamment avec des listes blanches. Compte tenu de leur nombre et de leur diversité, il ne nous est pas possible de les contacter individuellement pour entreprendre les démarches afin d'ajouter ign.fr dans chacune de leurs listes blanches. A la place, nous avons opté pour utiliser notre propre DNS et mettre en place une route proxy qui relaie ces requêtes à wxs.ign.fr.

Cela fonctionne très bien mais implique que nous forkions la bibliothèque, car la variable hostname est actuellement interne et non exposée:
https://github.com/IGNF/geoportal-access-lib/blob/master/src/Services/DefaultUrlService.js#L36

Serait-il possible d'exposer cette variable ou de la rendre configurable par quelque moyen que ce soit, pour permettre l'usage de cette bibliothèque à travers un proxy ? Cette pull request teste la présence d'une variable globale à cet effet, mais on peut bien sûr passer par la méthode de votre choix.

Merci d'avance