### PR TITLE
Making DefaultServiceUrl public

### DIFF
--- a/samples/Services/bundle-default-urls.html
+++ b/samples/Services/bundle-default-urls.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <script src="../../dist/GpServices-src.js"></script>
+    </head>
+    <body>
+        <h1>Obtention des URLs par defaut des services</h1>
+        <ul>
+        <li><b>Alti</b> : <span id="alti"></span></li>
+        <li><b>AutoComplete</b> : <span id="autocomplete"></span></li>
+        <li><b>AutoConf</b> : <span id="config"></span></li>
+        <li><b>Geocode</b> : <span id="geocode"></span></li>
+        <li><b>ProcessIsoCurve</b> : <span id="iso"></span></li>
+        <li><b>ReverseGeocode</b> : <span id="reverse"></span></li>
+        <li><b>Route</b> : <span id="route"></span></li>
+        </ul>
+        <script>
+              var span= null ;
+              // alti
+              span = document.getElementById("alti") ;
+              span.innerHTML = JSON.stringify(Gp.Services.DefaultUrl.Alti.url()) ;
+              // autocomplete
+              span = document.getElementById("autocomplete") ;
+              span.innerHTML = JSON.stringify(Gp.Services.DefaultUrl.AutoComplete.url()) ;
+              // Autoconf (getConfig)
+              span = document.getElementById("config") ;
+              span.innerHTML = JSON.stringify(Gp.Services.DefaultUrl.AutoConf.url(["KEY"])) ;
+              // geocode
+              span = document.getElementById("geocode") ;
+              span.innerHTML = JSON.stringify(Gp.Services.DefaultUrl.Geocode.url()) ;
+              // isocurve
+              span = document.getElementById("iso") ;
+              span.innerHTML = JSON.stringify(Gp.Services.DefaultUrl.ProcessIsoCurve.url()) ;
+              // reverse
+              span = document.getElementById("reverse") ;
+              span.innerHTML = JSON.stringify(Gp.Services.DefaultUrl.ReverseGeocode.url()) ;
+              // route
+              span = document.getElementById("route") ;
+              span.innerHTML = JSON.stringify(Gp.Services.DefaultUrl.Route.url()) ;
+        </script>
+    </body>
+</html>

--- a/src/Gp.js
+++ b/src/Gp.js
@@ -37,7 +37,9 @@ define([
     // Erreurs
     "Exceptions/ErrorService",
     // Outils
-    "Utils/Helper"
+    "Utils/Helper",
+    // URLs par defaut
+    "Services/DefaultUrlService"
 
 ],
     function (
@@ -61,7 +63,9 @@ define([
         // Erreurs
         Error,
         // Outils
-        Helper
+        Helper,
+        // URLs par defaut
+        DefaultUrl
         ) {
 
         "use strict";
@@ -144,6 +148,8 @@ define([
         // Export Erreurs et Outils
         Gp.extend("Error", Error);
         Gp.extend("Helper", Helper);
+        // Export DefaultUrls
+        Gp.extend("Services.DefaultUrl", DefaultUrl);
 
         // on sauvegarde la variable dans l'env.
         scope.Gp = Gp;

--- a/src/Services/DefaultUrlService.js
+++ b/src/Services/DefaultUrlService.js
@@ -44,8 +44,19 @@ define([], function () {
         return this._key.replace(key ? keyname : null, key);
     };
 
-    // liste des URLs des services
+    /**
+    * Default Geoportal web services URLs acces.
+    *
+    * @namespace 
+    * @alias Gp.Services.DefaultUrl
+    */
     var DefaultUrlService = {
+        /**
+         * Elevation web service acces
+         *
+         * @member {Object}
+         * @property {Function} url(key) - Returns elevation service default urls with or without geoportal access key given as a parameter. The result is a javascript object with different urls given used protocols ("elevation-json", "elevation-xml", "profil-json" or "profil-xml").
+         */
         Alti : {
             _key : {
                 // rest
@@ -69,6 +80,12 @@ define([], function () {
                 };
             }
         },
+        /**
+         * IsoCurve web service acces
+         *
+         * @member {Object}
+         * @property {Function} url(key) - Returns isocurve service default urls with or without geoportal access key given as a parameter. The result is a javascript object with different urls given used protocols ("iso-json" or "iso-xml").
+         */
         ProcessIsoCurve : {
             _key : {
                 "iso-json" : url + "/isochrone/isochrone.json", // rest (geoconcept)
@@ -82,14 +99,32 @@ define([], function () {
                 };
             }
         },
+        /**
+         * Autocompletion web service acces
+         *
+         * @member {Object}
+         * @property {Function} url(key) - Returns autocomplete service default urls with or without geoportal access key given as a parameter. The result is a String.
+         */
         AutoComplete : {
             _key : url + "/ols/apis/completion",
             url : fkey
         },
+        /**
+         * Reverse geocoding web service acces
+         *
+         * @member {Object}
+         * @property {Function} url(key) - Returns reverse geocoding service default urls with or without geoportal access key given as a parameter. The result is a String.
+         */
         ReverseGeocode : {
             _key : url + "/geoportail/ols",
             url : fkey
         },
+        /**
+         * Autoconfiguration web service acces
+         *
+         * @member {Object}
+         * @property {Function} url([key1,...]) - Returns autoconfiguration service default urls with geoportal access key(s) given as a String array parameter. The result is a javascript object with different urls given the access mode ("apiKey", "apiKeys" or "aggregate").
+         */
         AutoConf : {
             _key : {
                 apiKey : url + "/autoconf",
@@ -111,10 +146,22 @@ define([], function () {
                 };
             }
         },
+        /**
+         * Geocoding web service acces
+         *
+         * @member {Object}
+         * @property {Function} url(key) - Returns geocoding service default urls with or without geoportal access key given as a parameter. The result is a String.
+         */
         Geocode : {
             _key : url + "/geoportail/ols",
             url : fkey
         },
+        /**
+         * Routing web service acces
+         *
+         * @member {Object}
+         * @property {Function} url(key) - Returns routing service default urls with or without geoportal access key given as a parameter. The result is a javascript object with different urls given used protocols ("route-json" or "route-xml").
+         */
         Route : {
             _key : {
                 ols : url + "/itineraire/ols", // openLS


### PR DESCRIPTION
Pull request alternative à #22

La classe DefaultServiceUrl est désormais publique et accessible derrière l'alias : Gp.Services.DefaultUrl

Un nouvel exemple d'utilisation est disponible dans samples/Services/bundle-default-urls.html



