### PR TITLE
ajout de l'option onBeforeParse dans CommonService

### DIFF
--- a/src/Services/CommonService.js
+++ b/src/Services/CommonService.js
@@ -424,9 +424,9 @@ function (
                                     if (self.options.rawResponse) {
                                         content = response;
                                     }
-                                    if (typeof self.options.onBeforeParse === "function") {
+                                    if ( typeof self.options.onBeforeParse === "function") {
                                         var newResponse = self.options.onBeforeParse(content);
-                                        if (typeof newResponse === "string") {
+                                        if ( typeof newResponse === "string") {
                                             content = newResponse;
                                         }
                                     }

--- a/src/Services/CommonService.js
+++ b/src/Services/CommonService.js
@@ -78,6 +78,9 @@ function (
      * @param {Function} [options.onFailure] - Fonction appelée lorsque le service ne répond pas correctement
      *      (code HTTP de retour différent de 200 ou pas de réponse).
      *
+     * @param {Function} [options.onBeforeParse] - Fonction appelée avant le parsing de la réponse
+     *      Permet de modifier la réponse avant parsing si la fonction retourne une String.
+     *
      * @example
      *   var options = {
      *      apiKey : null,
@@ -89,8 +92,9 @@ function (
      *      timeOut : 10000, // ms
      *      rawResponse : false, // true|false
      *      scope : null, // this
-     *      onSuccess : function (response) {}
-     *      onFailure : function (error) {}
+     *      onSuccess : function (response) {},
+     *      onFailure : function (error) {},
+     *      onBeforeParse : function (rawResponse) {}
      *   };
      * @private
      */
@@ -419,6 +423,12 @@ function (
                                     content = response.xml; // par defaut !
                                     if (self.options.rawResponse) {
                                         content = response;
+                                    }
+                                    if (typeof self.options.onBeforeParse === "function") {
+                                        var newResponse = self.options.onBeforeParse(content);
+                                        if (typeof newResponse === "string") {
+                                            content = newResponse;
+                                        }
                                     }
                                 }
                             } else {

--- a/src/Services/CommonService.js
+++ b/src/Services/CommonService.js
@@ -80,6 +80,10 @@ function (
      *
      * @param {Function} [options.onBeforeParse] - Fonction appelée avant le parsing de la réponse
      *      Permet de modifier la réponse avant parsing si la fonction retourne une String.
+     *      Cette fonction prend en paramètre la réponse XML telle que renvoyée par le service,
+     *      sous la forme d'une chaîne de caractères (comportement par défaut).
+     *      Si le paramètre "rawResponse" a été précisé avec la valeur "true",
+     *      la fonction prend en paramètre un Object JavaScript contenant la réponse XML.
      *
      * @example
      *   var options = {

--- a/src/Services/Services.js
+++ b/src/Services/Services.js
@@ -36,6 +36,7 @@ define([
             * @param {String} [options.httpMethod=GET] - HTTP method to use when requesting underlying web service in case of a XHR protocol use (see above). Possible values are 'GET' and 'POST'. Ignored when options.protocol is set to 'JSONP' value. Only use if you know what you are doing.
             * @param {String} [options.contentType="application/xml"] - Content-Type to use when requesting underlying web service in case of a XHR protocol use (see above) and if method HTTP is POST. Ignored when options.protocol is set to 'JSONP' value. Only use if you know what you are doing.
             * @param {Boolean} [options.rawResponse=false] - Setting this parameter to true implies you want to handle the service response by yourself : it will be returned as an unparsed String in onSuccess callback parameter. Only use if you know what you are doing.
+            * @param {Function} [options.onBeforeParse] - Callback function to get service response before parsing (as an unparsed String), in case of a JSONP protocol use (see above). Takes a String as a parameter, except if "rawResponse" parameter is set to true : in this case parameter will be a JavaScript Object. Enables to modify response before parsing : the function needs to return a String that will be parsed as the service response. Ignored when options.protocol is set to 'JSONP' value. Only use if you know what you are doing.
             */
             getConfig : function (options) {
                 var autoconfService = new AutoConf(options);
@@ -65,6 +66,7 @@ define([
             * @param {String} [options.httpMethod=GET] - HTTP method to use when requesting underlying web service in case of a XHR protocol use (see above). Possible values are 'GET' and 'POST'. Ignored when options.protocol is set to 'JSONP' value. Only use if you know what you are doing.
             * @param {String} [options.contentType="application/xml"] - Content-Type to use when requesting underlying web service in case of a XHR protocol use (see above) and if method HTTP is POST. Ignored when options.protocol is set to 'JSONP' value. Only use if you know what you are doing.
             * @param {Boolean} [options.rawResponse=false] - Setting this parameter to true implies you want to handle the service response by yourself : it will be returned as an unparsed String in onSuccess callback parameter. Only use if you know what you are doing.
+            * @param {Function} [options.onBeforeParse] - Callback function to get service response before parsing (as an unparsed String), in case of a JSONP protocol use (see above). Takes a String as a parameter, except if "rawResponse" parameter is set to true : in this case parameter will be a JavaScript Object. Enables to modify response before parsing : the function needs to return a String that will be parsed as the service response. Ignored when options.protocol is set to 'JSONP' value. Only use if you know what you are doing.
             * @param {String} [options.api='REST'] - What API to use for interacting with underlying web service : 'REST' or 'WPS'. Only use if you know what you are doing.
             * @param {String} [options.outputFormat='json'] - Output format for underlying web service response : 'xml' or 'json'. Only use if you know what you are doing.
             */
@@ -124,6 +126,7 @@ define([
             * @param {String} [options.httpMethod=GET] - HTTP method to use when requesting underlying web service in case of a XHR protocol use (see above). Possible values are 'GET' and 'POST'. Ignored when options.protocol is set to 'JSONP' value. Only use if you know what you are doing.
             * @param {String} [options.contentType="application/xml"] - Content-Type to use when requesting underlying web service in case of a XHR protocol use (see above) and if method HTTP is POST. Ignored when options.protocol is set to 'JSONP' value. Only use if you know what you are doing.
             * @param {Boolean} [options.rawResponse=false] - Setting this parameter to true implies you want to handle the service response by yourself : it will be returned as an unparsed String in onSuccess callback parameter. Only use if you know what you are doing.
+            * @param {Function} [options.onBeforeParse] - Callback function to get service response before parsing (as an unparsed String), in case of a JSONP protocol use (see above). Takes a String as a parameter, except if "rawResponse" parameter is set to true : in this case parameter will be a JavaScript Object. Enables to modify response before parsing : the function needs to return a String that will be parsed as the service response. Ignored when options.protocol is set to 'JSONP' value. Only use if you know what you are doing.
             */
             geocode : function (options) {
                 var geocodeService = new Geocode(options);
@@ -154,6 +157,7 @@ define([
             * @param {String} [options.httpMethod=GET] - HTTP method to use when requesting underlying web service in case of a XHR protocol use (see above). Possible values are 'GET' and 'POST'. Ignored when options.protocol is set to 'JSONP' value. Only use if you know what you are doing.
             * @param {String} [options.contentType="application/xml"] - Content-Type to use when requesting underlying web service in case of a XHR protocol use (see above) and if method HTTP is POST. Ignored when options.protocol is set to 'JSONP' value. Only use if you know what you are doing.
             * @param {Boolean} [options.rawResponse=false] - Setting this parameter to true implies you want to handle the service response by yourself : it will be returned as an unparsed String in onSuccess callback parameter. Only use if you know what you are doing.
+            * @param {Function} [options.onBeforeParse] - Callback function to get service response before parsing (as an unparsed String), in case of a JSONP protocol use (see above). Takes a String as a parameter, except if "rawResponse" parameter is set to true : in this case parameter will be a JavaScript Object. Enables to modify response before parsing : the function needs to return a String that will be parsed as the service response. Ignored when options.protocol is set to 'JSONP' value. Only use if you know what you are doing.
             */
             reverseGeocode : function (options) {
                 var reverseGeocodeService = new ReverseGeocode(options);
@@ -179,6 +183,7 @@ define([
             * @param {String} [options.httpMethod=GET] - HTTP method to use when requesting underlying web service in case of a XHR protocol use (see above). Possible values are 'GET' and 'POST'. Ignored when options.protocol is set to 'JSONP' value. Only use if you know what you are doing.
             * @param {String} [options.contentType="application/xml"] - Content-Type to use when requesting underlying web service in case of a XHR protocol use (see above) and if method HTTP is POST. Ignored when options.protocol is set to 'JSONP' value. Only use if you know what you are doing.
             * @param {Boolean} [options.rawResponse=false] - Setting this parameter to true implies you want to handle the service response by yourself : it will be returned as an unparsed String in onSuccess callback parameter. Only use if you know what you are doing.
+            * @param {Function} [options.onBeforeParse] - Callback function to get service response before parsing (as an unparsed String), in case of a JSONP protocol use (see above). Takes a String as a parameter, except if "rawResponse" parameter is set to true : in this case parameter will be a JavaScript Object. Enables to modify response before parsing : the function needs to return a String that will be parsed as the service response. Ignored when options.protocol is set to 'JSONP' value. Only use if you know what you are doing.
             */
             autoComplete : function (options) {
                 var autoCompleteService = new AutoComplete(options);
@@ -210,6 +215,7 @@ define([
             * @param {String} [options.httpMethod=GET] - HTTP method to use when requesting underlying web service in case of a XHR protocol use (see above). Possible values are 'GET' and 'POST'. Ignored when options.protocol is set to 'JSONP' value. Only use if you know what you are doing.
             * @param {String} [options.contentType="application/xml"] - Content-Type to use when requesting underlying web service in case of a XHR protocol use (see above) and if method HTTP is POST. Ignored when options.protocol is set to 'JSONP' value. Only use if you know what you are doing.
             * @param {Boolean} [options.rawResponse=false] - Setting this parameter to true implies you want to handle the service response by yourself : it will be returned as an unparsed String in onSuccess callback parameter. Only use if you know what you are doing.
+            * @param {Function} [options.onBeforeParse] - Callback function to get service response before parsing (as an unparsed String), in case of a JSONP protocol use (see above). Takes a String as a parameter, except if "rawResponse" parameter is set to true : in this case parameter will be a JavaScript Object. Enables to modify response before parsing : the function needs to return a String that will be parsed as the service response. Ignored when options.protocol is set to 'JSONP' value. Only use if you know what you are doing.
             */
             route : function (options) {
                 var routeService = new Route(options);
@@ -241,6 +247,7 @@ define([
             * @param {String} [options.httpMethod=GET] - HTTP method to use when requesting underlying web service in case of a XHR protocol use (see above). Possible values are 'GET' and 'POST'. Ignored when options.protocol is set to 'JSONP' value. Only use if you know what you are doing.
             * @param {String} [options.contentType="application/xml"] - Content-Type to use when requesting underlying web service in case of a XHR protocol use (see above) and if method HTTP is POST. Ignored when options.protocol is set to 'JSONP' value. Only use if you know what you are doing.
             * @param {Boolean} [options.rawResponse=false] - Setting this parameter to true implies you want to handle the service response by yourself : it will be returned as an unparsed String in onSuccess callback parameter. Only use if you know what you are doing.
+            * @param {Function} [options.onBeforeParse] - Callback function to get service response before parsing (as an unparsed String), in case of a JSONP protocol use (see above). Takes a String as a parameter, except if "rawResponse" parameter is set to true : in this case parameter will be a JavaScript Object. Enables to modify response before parsing : the function needs to return a String that will be parsed as the service response. Ignored when options.protocol is set to 'JSONP' value. Only use if you know what you are doing.
             */
             isoCurve : function (options) {
                 var processIsoCurveService = new ProcessIsoCurve(options);


### PR DESCRIPTION
fix https://github.com/IGNF/geoportal-access-lib/issues/42
ping @lboulanger @gcebelieu 

L'utilisation de cette option se réduit à : 
```js
Gp.Services.getConfig({
	serverUrl: `${URL_PROXY_WXS}/${API_KEY}/autoconf`,
	onBeforeParse: function(xml){
		// remplacement des URL par notre proxy
		return xml.replace(/https:\/\/wxs.ign.fr/g, URL_PROXY_WXS)
	},
	onSuccess: resolve,
	onFailure: reject
});
```

Cela semble en effet être le meilleur compromis à la fois pour IGN et les utilisateurs