### PR TITLE
maj du template UMD

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,15 +41,31 @@ Prérequis : [NodeJS](https://nodejs.org/en/) et [npm](https://www.npmjs.com/) i
 npm install geoportal-access-lib
 ```
 
-
-
 ### Intégration dans une page web
 
-Intégrez la bibliothèque d'accès dans votre page WEB classiquement à l'aide d'une balise script.
-
+Intégrez la bibliothèque d'accès dans votre page WEB classiquement à l'aide d'une balise **script**.
 
 ``` html
 <script src="chemin/vers/GpServices.js"></script>
+```
+
+### Intégration dans [NodeJS](https://nodejs.org/en/)
+
+Intégrez la bibliothèque d'accès dans votre script à l'aide de la fonction **require**.
+
+``` js
+var Gp = require("chemin/vers/GpServices.js");
+```
+
+### Intégration dans un module ES6
+
+Intégrez la bibliothèque d'accès dans votre page WEB à l'aide d'une balise **script** de type *module*.
+
+``` html
+<script src="module">
+    import * as Gp from "chemin/vers/GpServices.js";
+    // puis, utilisation de la variable globale 'Gp' dans le module ES6...
+</script>
 ```
 
 ### Utilisation

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -205,10 +205,19 @@
                     });
                     cleaner.write(contents);
 
-                    // entête du bundle "es6-promise" est à modifier !
-                    // ex. es6Promise = typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() : typeof define === 'function' && define.amd ? define('es6-promise', factory) : global.ES6Promise = factory();
-                    _contentModified = (moduleName === "es6-promise") ? cleaner.toString().replace("typeof exports === 'object'", "es6Promise = typeof exports === 'object'") : cleaner.toString();
-                    
+                    // entête du bundle "es6-promise" est à modifier :
+                    //  ajouter variable
+                    //  compatibilité ES6 module
+
+                    if (moduleName === "es6-promise") {
+                        var _contentModuleA =  cleaner.toString();
+                        var _contentModuleB = _contentModuleA.replace("typeof exports === 'object'", "es6Promise = typeof exports === 'object'");
+                        var _contentModuleC = _contentModuleB.replace("this", "typeof self !== 'undefined' ? self : this");
+                        _contentModified = _contentModuleC;
+                    } else {
+                        _contentModified = cleaner.toString();
+                    }
+
                 } else {
                     _contentModified = contents;
                 }
@@ -269,6 +278,8 @@
 
         return gulp.src( path.join(build.js, (isDebug ? distFileNameDebug : distFileName)) )
             .pipe(umd({
+                /** template */
+                template : path.join(_.lib, "UMD.tpl"),
                 /** exports */
                 exports : function (file) {
                     return "Gp";

--- a/lib/README
+++ b/lib/README
@@ -3,3 +3,7 @@
 ### empty.js
 
 really empty javascript file used as a substitute to woodman when building geoportal-access-lib whithout debug mode (hack).
+
+### UMD.tpl
+
+update a template UMD (Universal Module Definition) used by gulp-umd (https://www.npmjs.com/package/gulp-umd).

--- a/lib/UMD.tpl
+++ b/lib/UMD.tpl
@@ -1,0 +1,14 @@
+;(function(root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    define(<%= amd %>, factory);
+  } else if (typeof exports === 'object' && module.exports) {
+    module.exports = factory(<%= cjs %>);
+  } else if(typeof exports === 'object') {
+    exports['<%= namespace %>'] = factory(<%= cjs %>);
+  } else {
+    root.<%= namespace %> = factory(<%= global %>);
+  }
+}(typeof self !== 'undefined' ? self : this, function(<%= param %>) {
+<%= contents %>
+return <%= exports %>;
+}));

--- a/samples/Services/Alti/ES6/es6-import-bundle-default.html
+++ b/samples/Services/Alti/ES6/es6-import-bundle-default.html
@@ -4,8 +4,7 @@
         <script type="module">
 
             // old synthax
-            import * as Gp from '../../../dist/GpServices-src.js';
-            console.log(Gp);
+            import * as Gp from '../../../../dist/GpServices-src.js';
 
                 var options = {
                     apiKey : 'jhyvi0fgmnuxvfv0zjzorvdn',

--- a/samples/Services/Alti/ES6/es6-module.js
+++ b/samples/Services/Alti/ES6/es6-module.js
@@ -1,0 +1,6 @@
+import * as Gp from "../../../../dist/GpServices-src.js";
+
+export function compute (options) {
+    // call self = window to get Gp (globale !)
+    self.Gp.Services.getAltitude(options);
+}

--- a/samples/Services/Alti/ES6/es6-page.html
+++ b/samples/Services/Alti/ES6/es6-page.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <script type="module">
+            import {compute} from "./es6-module.js";
+            compute({
+                apiKey : 'jhyvi0fgmnuxvfv0zjzorvdn',
+                onSuccess : function (response) {
+                    console.log(response.elevations);
+                },
+                onFailure : function (error) {
+                    console.log(error);
+                },
+                // spécifique au service
+                positions : [{lon:1.25, lat:47.48}]
+            })
+        </script>
+    </head>
+    <body>
+        <h1>Utilisation du service Alti avec les paramètres obligatoires seulement (options par défaut pour les autres)</h1>
+        <span>(Ouvrir la console)</span>
+    </body>
+</html>

--- a/samples/Services/Alti/es6-import-bundle-default.html
+++ b/samples/Services/Alti/es6-import-bundle-default.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <script type="module">
+
+            // old synthax
+            import * as Gp from '../../../dist/GpServices-src.js';
+            console.log(Gp);
+
+                var options = {
+                    apiKey : 'jhyvi0fgmnuxvfv0zjzorvdn',
+                    onSuccess : function (response) {console.log(response.elevations);},
+                    // spécifique au service
+                    positions : [{lon:1.25, lat:47.48}]
+                };
+
+                // call self = window to get Gp (globale !)
+                self.Gp.Services.getAltitude(options);
+
+            </script>
+    </head>
+    <body>
+        <h1>Utilisation du service Alti avec les paramètres obligatoires seulement (options par défaut pour les autres)</h1>
+        <span>(Ouvrir la console)</span>
+    </body>
+</html>


### PR DESCRIPTION
Maj du **template UMD** pour une compatibilité avec les environnements cjs, amd, es6 module...

Actuellement, on utilise **gulp-umd** pour générer l'entête **UMD** au bundle final.
Hors, ce projet n'a pas mis à jour ses _templates_ avec **UMDjs** (https://github.com/umdjs/umd)...

Les solutions possibles pour y remédier : 
1. faire une contribution à ce projet :  attendre que la PR soit validée  :-1:
2. créer notre propre _template_ en local : disponible immediatement :+1: 
3. changer d'utilitaire : peu d’évolution des projets consultés :-1: 
4. migration vers **webpack** : fortes évolutions, et c'est prévu mais c'est plus long à mettre en place :wave: 

Donc la solution d'utiliser un _template_ local est rapide mais temporaire, car en attente de migration vers **webpack**...