### PR TITLE
gestion du protocole http|https pour NodeJS

### DIFF
--- a/samples/Node/Services/node-alti-https.js
+++ b/samples/Node/Services/node-alti-https.js
@@ -1,0 +1,37 @@
+/* global module, require, __dirname */
+
+var requirejs = require("requirejs");
+
+requirejs.config({
+    baseUrl : __dirname + "/../../../src",
+    nodeRequire : require,
+    paths : {
+        // lib external
+        log4js : "../node_modules/woodman/dist/woodman-amd",
+        'es6-promise' : "../node_modules/es6-promise/dist/es6-promise",
+        // config du logger
+        "logger-cfg" : "Utils/Logger.cfg"
+    }
+});
+
+var Gp = requirejs("Gp");
+
+var options = {
+    apiKey : 'jhyvi0fgmnuxvfv0zjzorvdn',
+    httpMethod : 'GET',
+    outputFormat : 'json',
+    ssl : true,
+    onSuccess : function (response) {
+        console.log(response);
+    },
+    onFailure : function (error) {
+        console.log(eror);
+    },
+    // spécifique au service
+    positions : [{
+        lon : 1.25,
+        lat : 47.48
+    }]
+};
+
+Gp.Services.getAltitude(options);

--- a/samples/Node/Services/node-autocomplete-https.js
+++ b/samples/Node/Services/node-autocomplete-https.js
@@ -1,0 +1,39 @@
+/* global module, require, __dirname */
+
+var requirejs = require("requirejs");
+
+requirejs.config({
+    baseUrl : __dirname + "/../../../src",
+    nodeRequire : require,
+    paths : {
+        // lib external
+        log4js : "../node_modules/woodman/dist/woodman-amd",
+        'es6-promise' : "../node_modules/es6-promise/dist/es6-promise",
+        // config du logger
+        "logger-cfg" : "Utils/Logger.cfg"
+    }
+});
+
+var Gp = requirejs("Gp");
+
+var options = {
+    apiKey : 'jhyvi0fgmnuxvfv0zjzorvdn',
+    ssl : true,
+    // httpMethod : 'GET',
+    // outputFormat : 'json',
+    onSuccess : function (response) {
+        console.log(response);
+    },
+    onFailure : function (error) {
+        console.log(error);
+    },
+    // spécifique au service
+    text : process.argv[2] || "Saint-Mandé",
+    maximumResponses : process.argv[3] || 10,
+    filterOptions : {
+        type : (process.argv[4]) ? [process.argv[4]] : ["StreetAddress"],
+        territory : (process.argv[5]) ? [process.argv[5]] : ["METROPOLE"]
+    },
+};
+
+Gp.Services.autoComplete(options);

--- a/samples/Services/Alti/amd-rest-elevation.html
+++ b/samples/Services/Alti/amd-rest-elevation.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <script src="../../../node_modules/requirejs/require.js"></script>
+        <script>
+            /* global requirejs */
+            requirejs.config({
+                'baseUrl' : "../../../src/",
+                'paths': {
+                    // lib external
+                    'log4js' : "../node_modules/woodman/dist/woodman-amd",
+                    "es6-promise": "../node_modules/es6-promise/dist/es6-promise",
+                    // config du logger
+                    "logger-cfg" : "Utils/Logger.cfg"
+                }
+            });
+
+            requirejs(['Services/Alti/Alti'],
+                function (Alti) {
+
+                    var options = {
+                      apiKey : 'jhyvi0fgmnuxvfv0zjzorvdn',
+                      httpMethod : 'POST',
+                      protocol : 'XHR',
+                      onSuccess : function (response) {console.log(response.elevations);},
+                      onFailure : function (error) {console.log(error.message, error.status);},
+                      // spécifique au service
+                      positions : [{lon:1.25, lat:47.48}],
+                      outputFormat : 'json', // json|xml
+                      api : 'REST', // REST|WPS
+                      zonly : false // false|true
+                    };
+
+                    var o = new Alti(options);
+                    o.call();
+            });
+            </script>
+    </head>
+    <body>
+        <h1>Utilisation des modules natifs AMD sur les services</h1>
+        <span>(Ouvrir la console)</span>
+    </body>
+</html>

--- a/src/Protocols/XHR.js
+++ b/src/Protocols/XHR.js
@@ -174,12 +174,15 @@ function (Logger, Helper, ES6Promise, require) {
                             options.body = options.data;
                         }
 
+                        // FIXME ERROR : self signed certificate in certificate chain
+                        options.rejectUnauthorized = false;
+
                         req(options, function (error, response, body) {
 
                             if (!error && response.statusCode == 200 && body) {
                                 resolve(body);
                             } else {
-                                reject("Errors Occured on Http Request (nodejs) : " + body);
+                                reject("Errors Occured on Http Request (nodejs) : " + error);
                             }
                         });
                     } else {
@@ -366,7 +369,8 @@ function (Logger, Helper, ES6Promise, require) {
                     .then(JSON.parse)
                     .catch( function (error) {
                         console.log("_callJSON failed on : ", options.url, error);
-                        throw error;
+                        // FIXME pas d'exception, laissons le fil se derouler...
+                        // throw error;
                     });
         },
 
@@ -402,7 +406,8 @@ function (Logger, Helper, ES6Promise, require) {
                     })
                     .catch( function (error) {
                         console.log("__callXML failed on : ", options.url, error);
-                        throw error;
+                        // FIXME pas d'exception, laissons le fil se derouler...
+                        // throw error;
                     });
         }
 

--- a/src/Services/CommonService.js
+++ b/src/Services/CommonService.js
@@ -44,6 +44,11 @@ function (
      *      Par défaut, c'est le protocole XHR qui sera utilisé.
      *      Attention, le protocole JSONP n'est pas valide dans un environnement NodeJS (Utilisation du mode XHR).
      *
+     * @param {Boolean} [options.ssl] - Indique si l'on souhaite intérroger les services en https.
+     *      Ce paramètre ne fonctionne que pour une utilisation hors navigateur (ex. NodeJS).
+     *      Sur un navigateur, le protocole est automatiquement extrait de l'url du site...
+     *      Par défaut, on utilise le protocole http (ssl=false).
+     *
      * @param {String} [options.proxyURL] - Le proxy à utiliser pour pallier au problème de cross-domain dans le cas d'une requête XHR.
      *      Utile si le paramètre 'protocol' vaut 'XHR', il ne sera pas pris en compte si protocol vaut JSONP.
      *
@@ -90,6 +95,7 @@ function (
      *      apiKey : null,
      *      serverUrl : 'http://localhost/service/',
      *      protocol : 'JSONP', // JSONP|XHR
+     *      ssl : false,
      *      proxyURL : null,
      *      callbackName : null,
      *      httpMethod : 'GET', // GET|POST
@@ -122,6 +128,7 @@ function (
         this.options = {
             // protocol : "JSONP",
             protocol : "XHR",
+            ssl : false,
             proxyURL : "",
             // callbackName : "",
             callbackSuffix : null,
@@ -179,6 +186,7 @@ function (
             // gestion de l'url du service par defaut pour les services qui ne possèdent qu'une seul url par defaut
             // les cas particuliers des services avec plusieurs urls (ex. Alti) devront être traité dans la classe du composant
             // donc si l'url n'est pas renseignée, il faut utiliser les urls par defaut
+            DefaultUrlService.ssl = this.options.ssl;
             var urlByDefault = DefaultUrlService[this.CLASSNAME].url(this.options.apiKey);
             if ( typeof urlByDefault === "string" ) {
                 this.options.serverUrl = urlByDefault;

--- a/src/Services/DefaultUrlService.js
+++ b/src/Services/DefaultUrlService.js
@@ -30,29 +30,40 @@ define([], function () {
     // -> http://wxs.ign.fr/efe4r54tj4uy5i78o7545eaz7e87a/alti/rest/elevationLine.xml
     // -> http://wxs.ign.fr/efe4r54tj4uy5i78o7545eaz7e87a/alti/wps
     //
+    // Force ssl :
+    //
+    // DefaultUrlService.ssl = true;
+    // DefaultUrlService.AutoComplete.url('efe4r54tj4uy5i78o7545eaz7e87a')
+    // output {Object|String}
+    // -> https://wxs.ign.fr/efe4r54tj4uy5i78o7545eaz7e87a/ols/apis/completion
 
-    // protocol
-    var isBrowser = typeof window !== "undefined" ? true : false;
-    var protocol  = (isBrowser) ? (location && location.protocol && location.protocol.indexOf("https:") === 0 ? "https://" : "http://") :  "http://";
     // constantes internes
-    var hostname = "wxs.ign.fr";
-    var keyname  = "%KEY%";
-    var url = protocol + hostname.concat("/", keyname);
-
-    /** fonctions de substitutions */
-    var fkey = function (key) {
-        return this._key.replace(key ? keyname : null, key);
-    };
+    var ISBROWSER = typeof window !== "undefined" ? true : false;
+    var HOSTNAME  = "wxs.ign.fr";
 
     /**
-    * Default Geoportal web services URLs acces.
+    * Default Geoportal web services URLs access.
     *
-    * @namespace 
+    * @namespace
     * @alias Gp.Services.DefaultUrl
     */
     var DefaultUrlService = {
+
+        /** if set true, require the use of https protocol (except browser) */
+        ssl : false,
+
+        /** base url of services (ssl protocol management) */
+        url : function (key, path) {
+            // en mode browser, c'est le protocole du navigateur,
+            // sinon, il est fixé par l'option 'ssl' (par défaut à false, cad en http)
+            var _protocol = (ISBROWSER) ?
+                (location && location.protocol && location.protocol.indexOf("https:") === 0 ? "https://" : "http://") :
+                (DefaultUrlService.ssl ? "https://" : "http://");
+            return _protocol + HOSTNAME.concat("/", key, path);
+        },
+
         /**
-         * Elevation web service acces
+         * Elevation web service access
          *
          * @member {Object}
          * @property {Function} url(key) - Returns elevation service default urls with or without geoportal access key given as a parameter. The result is a javascript object with different urls given used protocols ("elevation-json", "elevation-xml", "profil-json" or "profil-xml").
@@ -60,75 +71,82 @@ define([], function () {
         Alti : {
             _key : {
                 // rest
-                "elevation-json" : url + "/alti/rest/elevation.json",
-                "elevation-xml" : url + "/alti/rest/elevation.xml",
-                "profil-json" : url + "/alti/rest/elevationLine.json",
-                "profil-xml" : url + "/alti/rest/elevationLine.xml",
+                "elevation-json" : "/alti/rest/elevation.json",
+                "elevation-xml" : "/alti/rest/elevation.xml",
+                "profil-json" : "/alti/rest/elevationLine.json",
+                "profil-xml" : "/alti/rest/elevationLine.xml",
                 // other
-                wps : url + "/alti/wps"
+                wps : "/alti/wps"
             },
             /** url */
             url : function (key) {
                 return {
                     // rest
-                    "elevation-json" : this._key["elevation-json"].replace(key ? keyname : null, key),
-                    "elevation-xml" : this._key["elevation-xml"].replace(key ? keyname : null, key),
-                    "profil-json" : this._key["profil-json"].replace(key ? keyname : null, key),
-                    "profil-xml" : this._key["profil-xml"].replace(key ? keyname : null, key),
+                    "elevation-json" : DefaultUrlService.url(key, this._key["elevation-json"]),
+                    "elevation-xml" : DefaultUrlService.url(key, this._key["elevation-xml"]),
+                    "profil-json" : DefaultUrlService.url(key, this._key["profil-json"]),
+                    "profil-xml" : DefaultUrlService.url(key, this._key["profil-xml"]),
                     // other
-                    wps : this._key.wps.replace(key ? keyname : null, key)
+                    wps : DefaultUrlService.url(key, this._key["wps"])
                 };
             }
         },
         /**
-         * IsoCurve web service acces
+         * IsoCurve web service access
          *
          * @member {Object}
          * @property {Function} url(key) - Returns isocurve service default urls with or without geoportal access key given as a parameter. The result is a javascript object with different urls given used protocols ("iso-json" or "iso-xml").
          */
         ProcessIsoCurve : {
             _key : {
-                "iso-json" : url + "/isochrone/isochrone.json", // rest (geoconcept)
-                "iso-xml" : url + "/isochrone/isochrone.xml"   // rest (geoconcept)
+                "iso-json" : "/isochrone/isochrone.json", // rest (geoconcept)
+                "iso-xml" : "/isochrone/isochrone.xml"   // rest (geoconcept)
             },
             /** url */
             url : function (key) {
                 return {
-                    "iso-json" : this._key["iso-json"].replace(key ? keyname : null, key),
-                    "iso-xml" : this._key["iso-xml"].replace(key ? keyname : null, key)
+                    "iso-json" : DefaultUrlService.url(key, this._key["iso-json"]),
+                    "iso-xml" : DefaultUrlService.url(key, this._key["iso-xml"])
                 };
             }
         },
         /**
-         * Autocompletion web service acces
+         * Autocompletion web service access
          *
          * @member {Object}
          * @property {Function} url(key) - Returns autocomplete service default urls with or without geoportal access key given as a parameter. The result is a String.
          */
         AutoComplete : {
-            _key : url + "/ols/apis/completion",
-            url : fkey
+            _key : "/ols/apis/completion",
+            /** url */
+            url : function (key) {
+                return DefaultUrlService.url(key, this._key);
+            }
         },
         /**
-         * Reverse geocoding web service acces
+         * Reverse geocoding web service access
          *
          * @member {Object}
          * @property {Function} url(key) - Returns reverse geocoding service default urls with or without geoportal access key given as a parameter. The result is a String.
          */
         ReverseGeocode : {
-            _key : url + "/geoportail/ols",
-            url : fkey
+            _key : "/geoportail/ols",
+            /** url */
+            url : function (key) {
+                return DefaultUrlService.url(key, this._key);
+            }
         },
         /**
-         * Autoconfiguration web service acces
+         * Autoconfiguration web service access
          *
          * @member {Object}
          * @property {Function} url([key1,...]) - Returns autoconfiguration service default urls with geoportal access key(s) given as a String array parameter. The result is a javascript object with different urls given the access mode ("apiKey", "apiKeys" or "aggregate").
          */
         AutoConf : {
             _key : {
-                apiKey : url + "/autoconf",
-                apiKeys : url + "/autoconf?keys=%KEYS%"
+                apiKey : "/autoconf",
+                apiKeys : "/autoconf?keys=%KEYS%",
+                aggregate : "/autoconf/id/"
             },
             /** url */
             url : function (key) {
@@ -140,40 +158,43 @@ define([], function () {
                     }
                 }
                 return {
-                    apiKey : this._key["apiKey"].replace(key ? keyname : null, key), // une seule clé
-                    apiKeys : this._key["apiKeys"].replace(keyname, key[0]).replace("%KEYS%", keys), // autoconf de plusieurs clés
-                    aggregate : protocol + hostname.concat("/") + key + "/autoconf/id/"
+                    apiKey : DefaultUrlService.url(key, this._key["apiKey"]), // une seule clé
+                    apiKeys : DefaultUrlService.url(key[0], this._key["apiKeys"]).replace("%KEYS%", keys), // autoconf de plusieurs clés
+                    aggregate :  DefaultUrlService.url(key, this._key["aggregate"])
                 };
             }
         },
         /**
-         * Geocoding web service acces
+         * Geocoding web service access
          *
          * @member {Object}
          * @property {Function} url(key) - Returns geocoding service default urls with or without geoportal access key given as a parameter. The result is a String.
          */
         Geocode : {
-            _key : url + "/geoportail/ols",
-            url : fkey
+            _key : "/geoportail/ols",
+            /** url */
+            url : function (key) {
+                return DefaultUrlService.url(key, this._key);
+            }
         },
         /**
-         * Routing web service acces
+         * Routing web service access
          *
          * @member {Object}
          * @property {Function} url(key) - Returns routing service default urls with or without geoportal access key given as a parameter. The result is a javascript object with different urls given used protocols ("route-json" or "route-xml").
          */
         Route : {
             _key : {
-                ols : url + "/itineraire/ols", // openLS
-                "route-json" : url + "/itineraire/rest/route.json", // rest (geoconcept)
-                "route-xml" : url + "/itineraire/rest/route.xml"   // rest (geoconcept)
+                ols : "/itineraire/ols", // openLS
+                "route-json" : "/itineraire/rest/route.json", // rest (geoconcept)
+                "route-xml" : "/itineraire/rest/route.xml"   // rest (geoconcept)
             },
             /** url */
             url : function (key) {
                 return {
-                    ols : this._key.ols.replace(key ? keyname : null, key),
-                    "route-json" : this._key["route-json"].replace(key ? keyname : null, key),
-                    "route-xml" : this._key["route-xml"].replace(key ? keyname : null, key)
+                    ols : DefaultUrlService.url(key, this._key["ols"]),
+                    "route-json" : DefaultUrlService.url(key, this._key["route-json"]),
+                    "route-xml" : DefaultUrlService.url(key, this._key["route-xml"])
                 };
             }
         }

--- a/test/spec/test_Services_DefaultUrlServices.js
+++ b/test/spec/test_Services_DefaultUrlServices.js
@@ -1,4 +1,4 @@
-/* 
+/*
  * Test des urls par défaut des services (utilisées si aucune url n'est spécifiée par l'utilisateur)
  */
 
@@ -9,13 +9,13 @@ define(['chai'], function (chai) {
     var should = chai.should();
 
     describe("-- Test DefaultUrlService --", function() {
-        
+
         describe('URLs par defaut des services', function () {
 
             var DefaultUrlService;
             var key = "CLE";
             var keys = ["CLE1", "CLE2"];
-            
+
             beforeEach(function(done) {
                 require(['Services/DefaultUrlService'], function(_DefaultUrlService) {
                     DefaultUrlService = _DefaultUrlService;
@@ -24,7 +24,7 @@ define(['chai'], function (chai) {
             });
 
             it('DefaultUrlService', function () {
-                
+
                 expect(DefaultUrlService.Alti.url(key)['elevation-json']).to.be.equal("http://wxs.ign.fr/CLE/alti/rest/elevation.json");
                 expect(DefaultUrlService.Alti.url(key)['elevation-xml']).to.be.equal('http://wxs.ign.fr/CLE/alti/rest/elevation.xml');
                 expect(DefaultUrlService.Alti.url(key)['profil-json']).to.be.equal('http://wxs.ign.fr/CLE/alti/rest/elevationLine.json');


### PR DESCRIPTION
* cf. PR https://github.com/IGNF/geoportal-extensions/pull/195
* cf. Issue https://github.com/IGNF/geoportal-extensions/issues/194

Implémentation de l'option **ssl** pour l’environnement **NodeJS** afin de pouvoir exécuter des requêtes en _HTTPS_ sur les services.

Cette option indique si l'on souhaite interroger les services en https.
* Ce paramètre ne fonctionne que pour une utilisation hors navigateur (ex. NodeJS).
* Ce paramètre n'a aucun effet sur un environnement navigateur car le protocole est extrait de l'url de la page en cours
* Par défaut, on utilise le protocole http (**ssl**=false)

Exemple : 

```
var Gp = requirejs("Gp");

var options = {
    apiKey : 'jhyvi0fgmnuxvfv0zjzorvdn',
    httpMethod : 'GET',
    outputFormat : 'json',
    ssl : true,
    onSuccess : function (response) {
        console.log(response);
    },
    onFailure : function (error) {
        console.log(eror);
    },
    // spécifique au service
    positions : [{
        lon : 1.25,
        lat : 47.48
    }]
};

Gp.Services.getAltitude(options);
```