### PR TITLE
Default Gp services URLs in https

### DIFF
--- a/src/Services/AutoConf/Formats/AutoConfResponseReader.js
+++ b/src/Services/AutoConf/Formats/AutoConfResponseReader.js
@@ -48,8 +48,8 @@ AutoConfResponseReader.NAMESPACES = {
  * Localisation (URL) du schema de définition du XML (XSD)
  */
 AutoConfResponseReader.SCHEMALOCATION = [
-    "http://www.opengis.net/context http://gpp3-wxs.ign.fr/schemas/extContext.xsd http://api.ign.fr/geoportail http://wxs.ign.fr/schemas/autoconf/autoconf.xsd",
-    "http://www.opengis.net/context http://gpp3-wxs.ign.fr/schemas/extContext.xsd http://api.ign.fr/geoportail http://gpp3-wxs.ign.fr/schemas/autoconf.xsd"
+    "http://www.opengis.net/context http://wxs.ign.fr/schemas/extContext.xsd http://api.ign.fr/geoportail http://wxs.ign.fr/schemas/autoconf/autoconf.xsd",
+    "http://www.opengis.net/context http://wxs.ign.fr/schemas/extContext.xsd http://api.ign.fr/geoportail http://wxs.ign.fr/schemas/autoconf.xsd"
 ];
 
 /**

--- a/src/Services/CommonService.js
+++ b/src/Services/CommonService.js
@@ -110,7 +110,7 @@ function CommonService (options) {
     this.options = {
         // protocol : "JSONP",
         protocol : "XHR",
-        ssl : false,
+        ssl : "auto",
         proxyURL : "",
         // callbackName : "",
         callbackSuffix : null,

--- a/src/Services/CommonService.js
+++ b/src/Services/CommonService.js
@@ -110,7 +110,7 @@ function CommonService (options) {
     this.options = {
         // protocol : "JSONP",
         protocol : "XHR",
-        ssl : "auto",
+        ssl : true,
         proxyURL : "",
         // callbackName : "",
         callbackSuffix : null,

--- a/src/Services/DefaultUrlService.js
+++ b/src/Services/DefaultUrlService.js
@@ -45,8 +45,8 @@ var HOSTNAME = "wxs.ign.fr";
  */
 var DefaultUrlService = {
 
-    /** if set true, require the use of https protocol (except browser) */
-    ssl : false,
+    /** if set true, require the use of https protocol */
+    ssl : "auto",
 
     /**
     * base url of services (ssl protocol management)
@@ -55,9 +55,16 @@ var DefaultUrlService = {
     * @returns {String} url
     */
     url : function (key, path) {
-        // en mode browser, on met du https par défaut,
-        // sinon, il est fixé par l'option 'ssl' (par défaut à false, cad en http)
-        var _protocol = (ISBROWSER) ? "https://" : (DefaultUrlService.ssl ? "https://" : "http://");
+        // comportement par défaut : en mode browser, on met du https, sinon http.
+        // sinon, il est fixé par l'option 'ssl' (true => https)
+        var _protocol;
+        
+        if ((DefaultUrlService.ssl === "auto" && ISBROWSER) || DefaultUrlService.ssl === true) {
+            _protocol = "https://";
+        } else {
+            _protocol = "http://";
+        }
+
         return _protocol + HOSTNAME.concat("/", key, path);
     },
 

--- a/src/Services/DefaultUrlService.js
+++ b/src/Services/DefaultUrlService.js
@@ -55,9 +55,9 @@ var DefaultUrlService = {
     * @returns {String} url
     */
     url : function (key, path) {
-        // en mode browser, c'est le protocole du navigateur,
+        // en mode browser, on met du https par défaut,
         // sinon, il est fixé par l'option 'ssl' (par défaut à false, cad en http)
-        var _protocol = (ISBROWSER) ? (location && location.protocol && location.protocol.indexOf("https:") === 0 ? "https://" : "http://") : (DefaultUrlService.ssl ? "https://" : "http://");
+        var _protocol = (ISBROWSER) ? "https://" : (DefaultUrlService.ssl ? "https://" : "http://");
         return _protocol + HOSTNAME.concat("/", key, path);
     },
 

--- a/src/Services/DefaultUrlService.js
+++ b/src/Services/DefaultUrlService.js
@@ -26,15 +26,16 @@
 // -> http://wxs.ign.fr/efe4r54tj4uy5i78o7545eaz7e87a/alti/rest/elevationLine.xml
 // -> http://wxs.ign.fr/efe4r54tj4uy5i78o7545eaz7e87a/alti/wps
 //
-// Force ssl :
+// ssl by default.
 //
-// DefaultUrlService.ssl = true;
+// Force to not do ssl :
+// DefaultUrlService.ssl = false;
+//
 // DefaultUrlService.AutoComplete.url('efe4r54tj4uy5i78o7545eaz7e87a')
 // output {Object|String}
 // -> https://wxs.ign.fr/efe4r54tj4uy5i78o7545eaz7e87a/ols/apis/completion
 
 // constantes internes
-var ISBROWSER = typeof window !== "undefined" ? 1 : 0;
 var HOSTNAME = "wxs.ign.fr";
 
 /**
@@ -46,7 +47,7 @@ var HOSTNAME = "wxs.ign.fr";
 var DefaultUrlService = {
 
     /** if set true, require the use of https protocol */
-    ssl : "auto",
+    ssl : true,
 
     /**
     * base url of services (ssl protocol management)
@@ -55,14 +56,14 @@ var DefaultUrlService = {
     * @returns {String} url
     */
     url : function (key, path) {
-        // comportement par défaut : en mode browser, on met du https, sinon http.
-        // sinon, il est fixé par l'option 'ssl' (true => https)
+        // comportement par défaut => https
+        // sinon, il est fixé par l'option 'ssl' (false => http)
         var _protocol;
         
-        if ((DefaultUrlService.ssl === "auto" && ISBROWSER) || DefaultUrlService.ssl === true) {
-            _protocol = "https://";
-        } else {
+        if (DefaultUrlService.ssl === false) {
             _protocol = "http://";
+        } else {
+            _protocol = "https://";
         }
 
         return _protocol + HOSTNAME.concat("/", key, path);

--- a/test/spec/test_Services_AutoConfResponse.js
+++ b/test/spec/test_Services_AutoConfResponse.js
@@ -220,8 +220,8 @@ describe("-- Tests AutoConfResponse --", function () {
             expect(AutoConfResponseReader).to.have.property("SCHEMALOCATION");
             expect(AutoConfResponseReader.SCHEMALOCATION).to.be.an("array");
             expect(AutoConfResponseReader.SCHEMALOCATION).to.have.length(2);
-            expect(AutoConfResponseReader.SCHEMALOCATION[0]).to.equal("http://www.opengis.net/context http://gpp3-wxs.ign.fr/schemas/extContext.xsd http://api.ign.fr/geoportail http://wxs.ign.fr/schemas/autoconf/autoconf.xsd");
-            expect(AutoConfResponseReader.SCHEMALOCATION[1]).to.equal("http://www.opengis.net/context http://gpp3-wxs.ign.fr/schemas/extContext.xsd http://api.ign.fr/geoportail http://gpp3-wxs.ign.fr/schemas/autoconf.xsd");
+            expect(AutoConfResponseReader.SCHEMALOCATION[0]).to.equal("http://www.opengis.net/context http://wxs.ign.fr/schemas/extContext.xsd http://api.ign.fr/geoportail http://wxs.ign.fr/schemas/autoconf/autoconf.xsd");
+            expect(AutoConfResponseReader.SCHEMALOCATION[1]).to.equal("http://www.opengis.net/context http://wxs.ign.fr/schemas/extContext.xsd http://api.ign.fr/geoportail http://wxs.ign.fr/schemas/autoconf.xsd");
             expect(AutoConfResponseReader).to.have.property("DEFAULTPREFIX", "context");
             expect(AutoConfResponseReader).to.have.property("READERS");
 

--- a/test/spec/test_Services_DefaultUrlServices.js
+++ b/test/spec/test_Services_DefaultUrlServices.js
@@ -18,21 +18,21 @@ describe("-- Test DefaultUrlService --", function () {
 
         it("DefaultUrlService", function () {
 
-            expect(DefaultUrlService.Alti.url(key)["elevation-json"]).to.be.equal("http://wxs.ign.fr/CLE/alti/rest/elevation.json");
-            expect(DefaultUrlService.Alti.url(key)["elevation-xml"]).to.be.equal("http://wxs.ign.fr/CLE/alti/rest/elevation.xml");
-            expect(DefaultUrlService.Alti.url(key)["profil-json"]).to.be.equal("http://wxs.ign.fr/CLE/alti/rest/elevationLine.json");
-            expect(DefaultUrlService.Alti.url(key)["profil-xml"]).to.be.equal("http://wxs.ign.fr/CLE/alti/rest/elevationLine.xml");
-            expect(DefaultUrlService.Alti.url(key)["wps"]).to.be.equal("http://wxs.ign.fr/CLE/alti/wps");
-            expect(DefaultUrlService.ProcessIsoCurve.url(key)["iso-json"]).to.be.equal("http://wxs.ign.fr/CLE/isochrone/isochrone.json");
-            expect(DefaultUrlService.ProcessIsoCurve.url(key)["iso-xml"]).to.be.equal("http://wxs.ign.fr/CLE/isochrone/isochrone.xml");
-            expect(DefaultUrlService.AutoComplete.url(key)).to.be.equal("http://wxs.ign.fr/CLE/ols/apis/completion" );
-            expect(DefaultUrlService.ReverseGeocode.url(key)).to.be.equal("http://wxs.ign.fr/CLE/geoportail/ols");
-            expect(DefaultUrlService.AutoConf.url(key)["apiKey"]).to.be.equal("http://wxs.ign.fr/CLE/autoconf");
-            expect(DefaultUrlService.AutoConf.url(keys)["apiKeys"]).to.be.equal("http://wxs.ign.fr/CLE1/autoconf?keys=CLE1,CLE2");
-            expect(DefaultUrlService.Geocode.url(key)).to.be.equal("http://wxs.ign.fr/CLE/geoportail/ols");
-            expect(DefaultUrlService.Route.url(key)["route-json"]).to.be.equal("http://wxs.ign.fr/CLE/itineraire/rest/route.json");
-            expect(DefaultUrlService.Route.url(key)["route-xml"]).to.be.equal("http://wxs.ign.fr/CLE/itineraire/rest/route.xml");
-            expect(DefaultUrlService.Route.url(key)["ols"]).to.be.equal("http://wxs.ign.fr/CLE/itineraire/ols");
+            expect(DefaultUrlService.Alti.url(key)["elevation-json"]).to.be.equal("https://wxs.ign.fr/CLE/alti/rest/elevation.json");
+            expect(DefaultUrlService.Alti.url(key)["elevation-xml"]).to.be.equal("https://wxs.ign.fr/CLE/alti/rest/elevation.xml");
+            expect(DefaultUrlService.Alti.url(key)["profil-json"]).to.be.equal("https://wxs.ign.fr/CLE/alti/rest/elevationLine.json");
+            expect(DefaultUrlService.Alti.url(key)["profil-xml"]).to.be.equal("https://wxs.ign.fr/CLE/alti/rest/elevationLine.xml");
+            expect(DefaultUrlService.Alti.url(key)["wps"]).to.be.equal("https://wxs.ign.fr/CLE/alti/wps");
+            expect(DefaultUrlService.ProcessIsoCurve.url(key)["iso-json"]).to.be.equal("https://wxs.ign.fr/CLE/isochrone/isochrone.json");
+            expect(DefaultUrlService.ProcessIsoCurve.url(key)["iso-xml"]).to.be.equal("https://wxs.ign.fr/CLE/isochrone/isochrone.xml");
+            expect(DefaultUrlService.AutoComplete.url(key)).to.be.equal("https://wxs.ign.fr/CLE/ols/apis/completion" );
+            expect(DefaultUrlService.ReverseGeocode.url(key)).to.be.equal("https://wxs.ign.fr/CLE/geoportail/ols");
+            expect(DefaultUrlService.AutoConf.url(key)["apiKey"]).to.be.equal("https://wxs.ign.fr/CLE/autoconf");
+            expect(DefaultUrlService.AutoConf.url(keys)["apiKeys"]).to.be.equal("https://wxs.ign.fr/CLE1/autoconf?keys=CLE1,CLE2");
+            expect(DefaultUrlService.Geocode.url(key)).to.be.equal("https://wxs.ign.fr/CLE/geoportail/ols");
+            expect(DefaultUrlService.Route.url(key)["route-json"]).to.be.equal("https://wxs.ign.fr/CLE/itineraire/rest/route.json");
+            expect(DefaultUrlService.Route.url(key)["route-xml"]).to.be.equal("https://wxs.ign.fr/CLE/itineraire/rest/route.xml");
+            expect(DefaultUrlService.Route.url(key)["ols"]).to.be.equal("https://wxs.ign.fr/CLE/itineraire/ols");
 
         });
     });


### PR DESCRIPTION
For the services, the ssl option is now set at true by default. To request the services in http, set the ssl parameter at false when calling the services.