### PR TITLE
OWC Context (POC)

### DIFF
--- a/src/Formats/OWC.js
+++ b/src/Formats/OWC.js
@@ -1,0 +1,127 @@
+import Logger from "../Utils/LoggerByDefault";
+import Schema from "./OWC/Schema";
+
+/**
+ * @classdesc
+ * 
+ * Construction d'un fichier JSON de context OWC
+ * {@link https://www.ogc.org/fr/publications/standard/owc/}
+ * 
+ * @constructor
+ * @alias Gp.Formats.OWC
+ *
+ * @param {Object} [options] - options du format OWC
+ * @example
+ * // appel via les services
+ * Gp.Services.getContext({
+ *      data : [{
+ *        name : "PLAN.IGN",
+ *        service : "TMS",
+ *      }],
+ *      configuration : {
+ *          type : "service", // ou service|json|object
+ *          url : "[url du service de recherche]" // data: "file.json" ou data: {}
+ *      },
+ *      onSuccess : (response) => {}
+ *      onFailure : (error) => {}
+ * });
+ * 
+ * // appel direct de la classe
+ * var owc = new OWC({
+ *  // conf tech issue de geoportal-configuration
+ *  data : {...},
+ *  // nom du template de transformation
+ *  template : "geoportal-configuration", 
+ *  // version du template
+ *  version : 1.0, 
+ * });
+ * owc.setVersion();
+ * owc.setData();
+ * owc.setTemplate();
+ * var context = owc.build();
+ */
+class OWC {
+    /**
+     * constructor
+     * @param {*} options 
+     */
+    constructor(options) {
+        
+        this.logger = Logger.getLogger();
+        this.logger.trace("[Constructeur OWC ()]");
+
+        // options par defaut
+        this.options = {};
+
+        // et on ajoute les options en paramètre aux options par défaut
+        for (var opt in options) {
+            if (options.hasOwnProperty(opt)) {
+                if (options[opt]) {
+                    this.options[opt] = options[opt];
+                }
+            }
+        }
+
+        this.setTemplate(this.options.template);
+        this.setVersion(this.options.version);
+        this.setData(this.options.data);
+        this.setAdditional(this.options.additional);
+
+        return this;
+    }
+
+    /**
+     * Nom du template de conversion vers le context
+     * @param {*} template 
+     */
+    setTemplate (template) {
+        this.template = template || "";
+    }
+
+    /**
+     * Format d'entrée en JSON
+     * @param {*} data 
+     */
+    setData (data) {
+        this.data = data || {};
+    }
+
+    /**
+     * Version du tempate de conversion
+     * @param {*} version 
+     */
+    setVersion (version) {
+        this.version = Number(version) || 1.0;
+    }
+
+    /**
+     * Données additionnelles
+     * @param {*} data 
+     */
+    setAdditional (data) {
+        this.additional = data || {};
+    }
+    
+    /**
+     * build
+     * @returns {Object} - 
+     * @fixme on ne traite qu'une seule donnée !
+     * @todo les données additionnelles !
+     */
+    build () {
+        var map = Schema.get(this.template, this.version);
+        if (! map) {
+            throw "[run OWC::build()] Erreur de récuperation du schema !"
+        }
+
+        var newSchema = Schema.transform(this.data, map);
+        if (! newSchema) {
+            throw "[run OWC::build()] Erreur de transformation de schema !";
+        }
+
+        return newSchema;
+    }
+
+}
+
+export default OWC;

--- a/src/Formats/OWC/Schema.js
+++ b/src/Formats/OWC/Schema.js
@@ -1,0 +1,252 @@
+/** Liste des properties de type classe : context et resource */
+const classType = {
+    "typeName:context" : {
+        "lang": "",
+        "title": "",
+        "subtitle": "",
+        "updated": "",
+        "publisher": "",
+        "date": "",
+        "generator": "",
+        "authors": [],
+        "contributors": [],
+        "categories": [],
+        "links": [],
+        "bbox": []
+    },
+    "typeName:resource" : {
+        "title": "",
+        "abstract": "",
+        "name": "", // added !
+        "service": "", // added !
+        "updated": "",
+        "publisher": "",
+        "date": "",
+        "active": true,
+        "opacity": 1, // added !
+        "visibility": true, // added !
+        "authors": [],
+        "contributors": [],
+        "offerings": [],
+        "categories": [],
+        "links": [],
+        "minscaledenominator": 0,
+        "maxscaledenominator": 0,
+    }
+};
+
+/** 
+ * Liste des properties de type data : 
+ * - offering 
+ * - operation
+ * - content
+ * - style
+ */
+const dataType = {
+    "typeName:offering" : {
+        "code": "",
+        "operations": [],
+        "contents": [],
+        "styles": []
+    },
+    "typeName:operation": {
+        "code": "",
+        "method": "",
+        "type": "",
+        "href": "",
+        "request": {},
+        "result": {}
+    },
+    "typeName:content": {
+        "code": "",
+        "title": "",
+        "href": "",
+        "content": ""
+    },
+    "typeName:style": {
+        "name": "",
+        "title": "",
+        "abstract": "",
+        "default": "",
+        "legendURL": "",
+        "content": ""
+    }
+};
+
+/** Liste des services */
+const offeringServiceExtension = [
+    "WMS",
+    "WMTS",
+    "TMS",
+    "WFS"
+];
+
+/** Liste des données de type fichier */
+const offeringInlineExtension = [
+    "KML",
+    "GPX",
+    "GEOJSON"
+];
+
+/** Liste des namespaces */
+const namespaces = {
+    "Core" : "http://www.opengis.net/spec/owc-geojson/1.0/req/core",
+    "WMS" : "http://www.opengis.net/spec/owc-geojson/1.0/req/wms",
+    "WMTS" : "http://www.opengis.net/spec/owc-geojson/1.0/req/wmts",
+    "WFS" : "http://www.opengis.net/spec/owc-geojson/1.0/req/wfs",
+    "TMS" : "http://www.opengis.net/tms/1.0",
+    "KML" : "http://www.opengis.net/spec/owc-geojson/1.0/req/kml",
+    "GPX" : "",
+    "GEOJSON" : ""
+};
+
+/**
+ * Transforme une emprise en geometrie geojson
+ * @param {*} bbox 
+ * @returns {Object} geometry
+ */
+const bbox2polygon = (bbox) => {
+    const bottomLeft = [bbox.left, bbox.bottom];
+    const topLeft = [bbox.left, bbox.top];
+    const topRight = [bbox.right, bbox.top];
+    const bottomRight = [bbox.right, bbox.bottom];
+
+  return {
+    "type" : "Polygon",
+    "coordinates" : [[bottomLeft, bottomRight, topRight, topLeft, bottomLeft]]
+  };
+};
+
+/**
+ * Liste des templates de transformations vers le context owc:
+ * - config
+ * - search
+ * - cartes.gouv.fr
+ */
+var TEMPLATES = [
+    {
+        version : 1.0,
+        name : "test",
+        schema : (data) => {
+            return {
+                person: {
+                    name: data.person.name
+                },
+                pets: {
+                    ...data.person.pets
+                }
+            };
+        }
+    },
+    {
+        version : 1.0,
+        name : "config",
+        schema : (data) => {
+            // data utiles
+            var key = data.key;
+            var service = data.serviceParams.id.split(":")[1] || null;
+            var name = data.name;
+            var version = data.serviceParams.version;
+            var server = data.serviceParams.serverUrl.full;
+            var format = data.formats[0].name;
+            var proj = data.defaultProjection;
+            var styles = data.styles;
+            // type d'offre
+            var offering = null;
+            if (service && offeringServiceExtension.includes(service)) {
+                switch (service) {
+                    case "WMS":
+                        offering = [{
+                            "code": namespaces.WMS,
+                            "operations": [
+                                {
+                                  "code": "GetCapabilities",
+                                  "method": "GET",
+                                  "type": "application/xml",
+                                  "href": server + "?SERVICE=WMS&VERSION=" + version + "&REQUEST=GetCapabilities",
+                                  "request": {},
+                                  "result": {}
+                                },
+                                {
+                                  "code": "GetMap",
+                                  "method": "GET",
+                                  "type": format,
+                                  "href": server + "?SERVICE=WMS&VERSION=" + version + "&REQUEST=GetMap&SRS=" + proj + "&BBOX=414475,4567125,451575,4588025&WIDTH=600&HEIGHT=400&LAYERS=" + name + "&FORMAT=" + format + "&STYLES=",
+                                  "request": {},
+                                  "result": {}
+                                },
+                                {
+                                    "code": "GetLegendGraphic",
+                                    "method": "GET",
+                                    "type": format,
+                                    "href": server + "?SERVICE=WMS&VERSION=" + version + "&REQUEST=GetLegendGraphic&WIDTH=20&HEIGHT=20&LAYER=" + name + "&FORMAT=" + format,
+                                    "request": {},
+                                    "result": {}
+                                }
+                            ],
+                            "contents": [],
+                            "styles": styles
+                        }];
+                        break;
+                
+                    default:
+                        break;
+                }
+            }
+            return {
+                "type": "FeatureCollection",
+                "id": "http://www.opengis.net/owc/1.0/" + key,
+                "geometry": bbox2polygon(data.globalConstraint.bbox),
+                "properties": {
+                    "lang": "fr-FR",
+                    "title": "",
+                    "subtitle": "",
+                    "updated": "",
+                    "generator": "cartes.gouv.fr",
+                    "authors": [{ "name": "cartes.gouv.fr" }],
+                    "contributors": [],
+                    "categories": [],
+                    "links": [
+                        {
+                            "rel": "profile",
+                            "href": namespaces.Core,
+                            "title": "This file is compliant with version 1.0 of OGC Context"
+                        }
+                    ]
+                },
+                "features": [{
+                    "type": "Feature",
+                    "id": server + "/" + name,
+                    "geometry": bbox2polygon(data.globalConstraint.bbox),
+                    "properties": {
+                        "title": data.title,
+                        "updated": "",
+                        "content": data.description,
+                        "authors": [],
+                        "contributors": [],
+                        "categories": [],
+                        "links": data.metadata,
+                        "offerings": offering || [],
+                        "minscaledenominator": data.globalConstraint.minScaleDenominator || 0,
+                        "maxscaledenominator": data.globalConstraint.maxScaleDenominator || 0,
+                    }
+                }]
+            };
+        }
+    }
+];
+
+var Schema = {
+    get : (name, version) => {
+        return TEMPLATES.find((el) => {
+            if (el.name === name && el.version === version) {
+                return true;
+            }
+        });
+    },
+    transform : (data, map) => {
+        return map.schema(data);
+    },
+};
+
+export default Schema;

--- a/src/Formats/OWC/data/sample-config.json
+++ b/src/Formats/OWC/data/sample-config.json
@@ -1,0 +1,124 @@
+{
+    "name": "ACCES.BIOMETHANE",
+    "title": "Cartographie biométhane d’accès aux réseaux",
+    "description": "Cette cartographie indique un premier ordre degrandeur du critère technico-économique exprimé en euro/Normalm3/h (€/Nm3/h): plus la valeur de ce critère est basse, meilleures sont les possibilités pour les opérateurs de réseau de réaliser des renforcements pour accueillir du biométhane sur la zone.",
+    "globalConstraint": {
+        "minScaleDenominator": 0,
+        "maxScaleDenominator": 62236752975597,
+        "bbox": {
+            "left": -5.13901729,
+            "right": 8.23029497,
+            "top": 51.0893967,
+            "bottom": 42.33348862
+        }
+    },
+    "serviceParams": {
+        "id": "OGC:WMS",
+        "version": "1.3.0",
+        "serverUrl": {
+            "full": "https://data.geopf.fr/wms-v/ows"
+        }
+    },
+    "defaultProjection": "EPSG:4326",
+    "queryable": true,
+    "metadata": [],
+    "styles": [
+        {
+            "name": "default-style-ACCES.BIOMETHANE",
+            "title": "ACCES.BIOMETHANE style"
+        }
+    ],
+    "legends": [
+        {
+            "format": "image/png",
+            "url": "https://data.geopf.fr/wms-v/ows?service=WMS&version=1.3.0&request=GetLegendGraphic&format=image%2Fpng&width=20&height=20&layer=ACCES.BIOMETHANE"
+        }
+    ],
+    "formats": [
+        {
+            "name": "image/png",
+            "current": true
+        },
+        {
+            "name": "application/atom+xml",
+            "current": false
+        },
+        {
+            "name": "application/json;type=utfgrid",
+            "current": false
+        },
+        {
+            "name": "application/pdf",
+            "current": false
+        },
+        {
+            "name": "application/rss+xml",
+            "current": false
+        },
+        {
+            "name": "application/vnd.google-earth.kml+xml",
+            "current": false
+        },
+        {
+            "name": "application/vnd.google-earth.kml+xml;mode=networklink",
+            "current": false
+        },
+        {
+            "name": "application/vnd.google-earth.kmz",
+            "current": false
+        },
+        {
+            "name": "image/geotiff",
+            "current": false
+        },
+        {
+            "name": "image/geotiff8",
+            "current": false
+        },
+        {
+            "name": "image/gif",
+            "current": false
+        },
+        {
+            "name": "image/jpeg",
+            "current": false
+        },
+        {
+            "name": "image/png; mode=8bit",
+            "current": false
+        },
+        {
+            "name": "image/svg+xml",
+            "current": false
+        },
+        {
+            "name": "image/tiff",
+            "current": false
+        },
+        {
+            "name": "image/tiff8",
+            "current": false
+        },
+        {
+            "name": "image/vnd.jpeg-png",
+            "current": false
+        },
+        {
+            "name": "image/vnd.jpeg-png8",
+            "current": false
+        },
+        {
+            "name": "text/html; subtype=openlayers",
+            "current": false
+        },
+        {
+            "name": "text/html; subtype=openlayers2",
+            "current": false
+        },
+        {
+            "name": "text/html; subtype=openlayers3",
+            "current": false
+        }
+    ],
+    "key": "ACCES.BIOMETHANE$GEOPORTAIL:OGC:WMS"
+}

--- a/src/Formats/OWC/data/sample-owc.json
+++ b/src/Formats/OWC/data/sample-owc.json
@@ -1,0 +1,84 @@
+{
+  "type": "FeatureCollection",
+  "id": "http://www.opengis.net/owc/1.0/examples/WMS_scale",
+  "geometry": {
+    "type": "Polygon",
+    "coordinates": [
+      [
+        [4567125, 414475],
+        [4567125, 451575],
+        [4588025, 451575],
+        [4588025, 414475],
+        [4567125, 414475]
+      ]
+    ]
+  },
+  "properties": {
+    "lang": "ca-CA",
+    "title": "Ortofotoimatge de Barcelona 1:5 000 [ICC]",
+    "subtitle": "Finestra l'ortofotoimatge de Catalunya 1:5 000 [ICC]",
+    "updated": "2012-11-04T17:26:23Z",
+    "generator": "MiraMon",
+    "authors": [{ "name": "Joan Masó" }],
+    "contributors": [],
+    "categories": [],
+    "links": [
+      {
+        "rel": "profile",
+        "href": "http://www.opengis.net/spec/owc-atom/1.0/req/core",
+        "title": "This file is compliant with version 1.0 of OGC Context"
+      }
+    ]
+  },
+  "features": [
+    {
+      "type": "Feature",
+      "id": "http://shagrat.icc.es/lizardtech/iserv/ows/orto5m",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [4567125, 414475],
+            [4567125, 451575],
+            [4588025, 451575],
+            [4588025, 414475],
+            [4567125, 414475]
+          ]
+        ]
+      },
+      "properties": {
+        "title": "Ortofotoimatge de Barcelona 1:5 000 [ICC]",
+        "updated": "2011-11-01T00:00:00Z",
+        "content": "Ortofotoimatge de Barcelona 1:5 000 de l'Institut Cartogràfic de Catalunya (la més actual disponible)",
+        "authors": [{ "name": "ICC", "email": "icc@icc.cat" }],
+        "contributors": [],
+        "categories": [],
+        "links": [],
+        "offerings": [
+          {
+            "code": "http://www.opengis.net/spec/owc-atom/1.0/req/wms",
+            "operations": [
+              {
+                "code": "GetCapabilities",
+                "method": "GET",
+                "type": "application/xml",
+                "href": "http://shagrat.icc.es/lizardtech/iserv/ows?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetCapabilities",
+                "request": {},
+                "result": {}
+              },
+              {
+                "code": "GetMap",
+                "method": "GET",
+                "type": "image/jpeg",
+                "href": "http://shagrat.icc.es/lizardtech/iserv/ows?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetMap&SRS=EPSG:23031&BBOX=414475,4567125,451575,4588025&WIDTH=600&HEIGHT=400&LAYERS=orto5m&FORMAT=image/jpeg&STYLES=",
+                "request": {},
+                "result": {}
+              }
+            ],
+            "contents": []
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/src/Formats/OWC/data/schema-config.json
+++ b/src/Formats/OWC/data/schema-config.json
@@ -1,0 +1,630 @@
+
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "jsdoc": "schema.jsdoc",
+    "title": "Generated schema for configuration service",
+    "type": "object",
+    "properties": {
+      "generalOptions": {
+        "type": "object",
+        "properties": {
+          "apiKeys": {
+            "type": "object",
+            "properties": {
+              "$apikey": {
+                "type": "array",
+                "items": {}
+              }
+            },
+            "required": [
+              "$apikey"
+            ]
+          }
+        },
+        "required": [
+          "apiKeys"
+        ]
+      },
+      "layers": {
+        "type": "object",
+        "properties": {
+          "$GEOPORTAIL:OGC:WMTS": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "globalConstraint": {
+                "type": "object",
+                "properties": {
+                  "maxScaleDenominator": {
+                    "type": "number"
+                  },
+                  "minScaleDenominator": {
+                    "type": "number"
+                  },
+                  "bbox": {
+                    "type": "object",
+                    "properties": {
+                      "left": {
+                        "type": "number"
+                      },
+                      "right": {
+                        "type": "number"
+                      },
+                      "top": {
+                        "type": "number"
+                      },
+                      "bottom": {
+                        "type": "number"
+                      }
+                    },
+                    "required": [
+                      "left",
+                      "right",
+                      "top",
+                      "bottom"
+                    ]
+                  }
+                },
+                "required": [
+                  "maxScaleDenominator",
+                  "minScaleDenominator",
+                  "bbox"
+                ]
+              },
+              "serviceParams": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "version": {
+                    "type": "string"
+                  },
+                  "serverUrl": {
+                    "type": "object",
+                    "properties": {
+                      "$apikey": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "$apikey"
+                    ]
+                  }
+                },
+                "required": [
+                  "id",
+                  "version",
+                  "serverUrl"
+                ]
+              },
+              "defaultProjection": {
+                "type": "string"
+              },
+              "wmtsOptions": {
+                "type": "object",
+                "properties": {
+                  "tileMatrixSetLink": {
+                    "type": "string"
+                  },
+                  "tileMatrixSetLimits": {
+                    "type": "object",
+                    "properties": {
+                      "$level": {
+                        "type": "object",
+                        "properties": {
+                          "minTileRow": {
+                            "type": "string"
+                          },
+                          "maxTileRow": {
+                            "type": "string"
+                          },
+                          "minTileCol": {
+                            "type": "string"
+                          },
+                          "maxTileCol": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "minTileRow",
+                          "maxTileRow",
+                          "minTileCol",
+                          "maxTileCol"
+                        ]
+                      }
+                    },
+                    "required": [
+                      "$level"
+                    ]
+                  }
+                },
+                "required": [
+                  "tileMatrixSetLink",
+                  "tileMatrixSetLimits"
+                ]
+              },
+              "styles": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "current": {
+                      "type": "boolean"
+                    },
+                    "url": {}
+                  },
+                  "required": [
+                    "name",
+                    "title",
+                    "current",
+                    "url"
+                  ]
+                }
+              },
+              "legends": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "format": {
+                      "type": "string"
+                    },
+                    "url": {
+                      "type": "string"
+                    },
+                    "minScaleDenominator": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "format",
+                    "url",
+                    "minScaleDenominator"
+                  ]
+                }
+              },
+              "formats": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "current": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "current"
+                  ]
+                }
+              }
+            },
+            "required": [
+              "name",
+              "title",
+              "description",
+              "globalConstraint",
+              "serviceParams",
+              "defaultProjection",
+              "wmtsOptions",
+              "styles",
+              "legends",
+              "formats"
+            ]
+          },
+          "$GEOPORTAIL:OGC:WMS": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "globalConstraint": {
+                "type": "object",
+                "properties": {
+                  "minScaleDenominator": {
+                    "type": "number"
+                  },
+                  "maxScaleDenominator": {
+                    "type": "number"
+                  },
+                  "bbox": {
+                    "type": "object",
+                    "properties": {
+                      "left": {
+                        "type": "number"
+                      },
+                      "right": {
+                        "type": "number"
+                      },
+                      "top": {
+                        "type": "number"
+                      },
+                      "bottom": {
+                        "type": "number"
+                      }
+                    },
+                    "required": [
+                      "left",
+                      "right",
+                      "top",
+                      "bottom"
+                    ]
+                  }
+                },
+                "required": [
+                  "minScaleDenominator",
+                  "maxScaleDenominator",
+                  "bbox"
+                ]
+              },
+              "serviceParams": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "version": {
+                    "type": "string"
+                  },
+                  "serverUrl": {
+                    "type": "object",
+                    "properties": {
+                      "$apikey": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "$apikey"
+                    ]
+                  }
+                },
+                "required": [
+                  "id",
+                  "version",
+                  "serverUrl"
+                ]
+              },
+              "defaultProjection": {
+                "type": "string"
+              },
+              "queryable": {
+                "type": "boolean"
+              },
+              "metadata": {
+                "type": "array",
+                "items": {}
+              },
+              "styles": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "title"
+                  ]
+                }
+              },
+              "legends": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "format": {
+                      "type": "string"
+                    },
+                    "url": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "format",
+                    "url"
+                  ]
+                }
+              },
+              "formats": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "current": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "current"
+                  ]
+                }
+              }
+            },
+            "required": [
+              "name",
+              "title",
+              "description",
+              "globalConstraint",
+              "serviceParams",
+              "defaultProjection",
+              "queryable",
+              "metadata",
+              "styles",
+              "legends",
+              "formats"
+            ]
+          },
+          "$GEOPORTAIL:GPP:TMS": {
+            "type": "object",
+            "properties": {
+              "hidden": {
+                "type": "boolean"
+              },
+              "queryable": {
+                "type": "boolean"
+              },
+              "serviceParams": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "version": {
+                    "type": "string"
+                  },
+                  "serverUrl": {
+                    "type": "object",
+                    "properties": {
+                      "$apikey": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "$apikey"
+                    ]
+                  }
+                },
+                "required": [
+                  "id",
+                  "version",
+                  "serverUrl"
+                ]
+              },
+              "name": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "formats": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "current": {
+                      "type": "boolean"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "current",
+                    "name"
+                  ]
+                }
+              },
+              "styles": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "current": {
+                      "type": "boolean"
+                    },
+                    "url": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "title",
+                    "current",
+                    "url"
+                  ]
+                }
+              },
+              "globalConstraint": {
+                "type": "object",
+                "properties": {
+                  "crs": {
+                    "type": "string"
+                  },
+                  "bbox": {
+                    "type": "object",
+                    "properties": {
+                      "left": {
+                        "type": "number"
+                      },
+                      "right": {
+                        "type": "number"
+                      },
+                      "top": {
+                        "type": "number"
+                      },
+                      "bottom": {
+                        "type": "number"
+                      }
+                    },
+                    "required": [
+                      "left",
+                      "right",
+                      "top",
+                      "bottom"
+                    ]
+                  },
+                  "minScaleDenominator": {},
+                  "maxScaleDenominator": {}
+                },
+                "required": [
+                  "crs",
+                  "bbox",
+                  "minScaleDenominator",
+                  "maxScaleDenominator"
+                ]
+              },
+              "layerId": {
+                "type": "string"
+              },
+              "defaultProjection": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "hidden",
+              "queryable",
+              "serviceParams",
+              "name",
+              "title",
+              "description",
+              "formats",
+              "styles",
+              "globalConstraint",
+              "layerId",
+              "defaultProjection"
+            ]
+          }
+        },
+        "required": []
+      },
+      "tileMatrixSets": {
+        "type": "object",
+        "properties": {
+          "$tmsid": {
+            "type": "object",
+            "properties": {
+              "projection": {
+                "type": "string"
+              },
+              "nativeResolutions": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "tileMatrices": {
+                "type": "object",
+                "properties": {
+                  "$level": {
+                    "type": "object",
+                    "properties": {
+                      "matrixId": {
+                        "type": "string"
+                      },
+                      "matrixHeight": {
+                        "type": "number"
+                      },
+                      "matrixWidth": {
+                        "type": "number"
+                      },
+                      "scaleDenominator": {
+                        "type": "number"
+                      },
+                      "tileHeight": {
+                        "type": "number"
+                      },
+                      "tileWidth": {
+                        "type": "number"
+                      },
+                      "topLeftCorner": {
+                        "type": "object",
+                        "properties": {
+                          "x": {
+                            "type": "number"
+                          },
+                          "y": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "x",
+                          "y"
+                        ]
+                      }
+                    },
+                    "required": [
+                      "matrixId",
+                      "matrixHeight",
+                      "matrixWidth",
+                      "scaleDenominator",
+                      "tileHeight",
+                      "tileWidth",
+                      "topLeftCorner"
+                    ]
+                  }
+                },
+                "required": [
+                  "$level"
+                ]
+              }
+            },
+            "required": [
+              "projection",
+              "nativeResolutions",
+              "tileMatrices"
+            ]
+          }
+        },
+        "required": [
+          "$tmsid"
+        ]
+      }
+    },
+    "required": [
+      "generalOptions",
+      "layers",
+      "tileMatrixSets"
+    ]
+}

--- a/src/Formats/OWC/data/schema-owc.json
+++ b/src/Formats/OWC/data/schema-owc.json
@@ -1,0 +1,82 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "OWS Context JSON schema",
+    "type": "object",  
+    "properties": {
+      "type": { "enum": ["FeatureCollection"] },
+      "properties": {
+        "type": "object",
+        "properties": {
+          "lang": { "type": "string" },
+          "id": { "type": "string", "format": "uri" },
+          "title": { "type": "string" },
+          "subtitle": { "type": "string" },
+          "updated": { "type": "string" },
+          "authors": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": { "type": "string" }
+              }
+            }
+          },
+          "categories": { "type": "array" },
+          "contributors": { "type": "array" },
+          "links": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "rel": { "enum": ["profile"] },
+                "href": { "type": "string", "format": "uri" },
+                "title": { "type": "string" }
+              }
+            }
+          }
+        }
+      },
+      "features": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "type": { "enum": ["Feature"] },
+            "geometry": { "type": "object" },
+            "properties": {
+              "type": "object",
+              "properties": {
+                "id": { "type": "string", "format": "uri" },
+                "title": { "type": "string" },
+                "updated": { "type": "string" },
+                "content": { "type": "string" },
+                "categories": { "type": "array" },
+                "links": { "type": "array" },
+                "offerings": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "code": { "type": "string", "format": "uri" },
+                      "operations": { "type": "array" },
+                      "contents": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "type": { "type": "string" },
+                            "href": { "type": "string", "format": "uri" },
+                            "content": { "type": "string" }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+}

--- a/test/spec/fixtures/wms-config-1.0.js
+++ b/test/spec/fixtures/wms-config-1.0.js
@@ -1,0 +1,126 @@
+var dataWmsConfig = {
+    "name": "ACCES.BIOMETHANE",
+    "title": "Cartographie biométhane d’accès aux réseaux",
+    "description": "Cette cartographie indique un premier ordre degrandeur du critère technico-économique exprimé en euro/Normalm3/h (€/Nm3/h): plus la valeur de ce critère est basse, meilleures sont les possibilités pour les opérateurs de réseau de réaliser des renforcements pour accueillir du biométhane sur la zone.",
+    "globalConstraint": {
+        "minScaleDenominator": 0,
+        "maxScaleDenominator": 62236752975597,
+        "bbox": {
+            "left": -5.13901729,
+            "right": 8.23029497,
+            "top": 51.0893967,
+            "bottom": 42.33348862
+        }
+    },
+    "serviceParams": {
+        "id": "OGC:WMS",
+        "version": "1.3.0",
+        "serverUrl": {
+            "full": "https://data.geopf.fr/wms-v/ows"
+        }
+    },
+    "defaultProjection": "EPSG:4326",
+    "queryable": true,
+    "metadata": [],
+    "styles": [
+        {
+            "name": "default-style-ACCES.BIOMETHANE",
+            "title": "ACCES.BIOMETHANE style"
+        }
+    ],
+    "legends": [
+        {
+            "format": "image/png",
+            "url": "https://data.geopf.fr/wms-v/ows?service=WMS&version=1.3.0&request=GetLegendGraphic&format=image%2Fpng&width=20&height=20&layer=ACCES.BIOMETHANE"
+        }
+    ],
+    "formats": [
+        {
+            "name": "image/png",
+            "current": true
+        },
+        {
+            "name": "application/atom+xml",
+            "current": false
+        },
+        {
+            "name": "application/json;type=utfgrid",
+            "current": false
+        },
+        {
+            "name": "application/pdf",
+            "current": false
+        },
+        {
+            "name": "application/rss+xml",
+            "current": false
+        },
+        {
+            "name": "application/vnd.google-earth.kml+xml",
+            "current": false
+        },
+        {
+            "name": "application/vnd.google-earth.kml+xml;mode=networklink",
+            "current": false
+        },
+        {
+            "name": "application/vnd.google-earth.kmz",
+            "current": false
+        },
+        {
+            "name": "image/geotiff",
+            "current": false
+        },
+        {
+            "name": "image/geotiff8",
+            "current": false
+        },
+        {
+            "name": "image/gif",
+            "current": false
+        },
+        {
+            "name": "image/jpeg",
+            "current": false
+        },
+        {
+            "name": "image/png; mode=8bit",
+            "current": false
+        },
+        {
+            "name": "image/svg+xml",
+            "current": false
+        },
+        {
+            "name": "image/tiff",
+            "current": false
+        },
+        {
+            "name": "image/tiff8",
+            "current": false
+        },
+        {
+            "name": "image/vnd.jpeg-png",
+            "current": false
+        },
+        {
+            "name": "image/vnd.jpeg-png8",
+            "current": false
+        },
+        {
+            "name": "text/html; subtype=openlayers",
+            "current": false
+        },
+        {
+            "name": "text/html; subtype=openlayers2",
+            "current": false
+        },
+        {
+            "name": "text/html; subtype=openlayers3",
+            "current": false
+        }
+    ],
+    "key": "ACCES.BIOMETHANE$GEOPORTAIL:OGC:WMS"
+};
+
+export default dataWmsConfig;

--- a/test/spec/test_Formats_OWC.js
+++ b/test/spec/test_Formats_OWC.js
@@ -1,0 +1,77 @@
+import { assert } from "chai";
+import { expect } from "chai";
+import { should } from "chai";
+should();
+
+import OWC from "../../src/Formats/OWC";
+import dataWmsConfig from "./fixtures/wms-config-1.0";
+
+describe("-- Test for OWC --", function () {
+
+    var dataTest = {
+        person: {
+            name: "Edgar",
+            pets: {
+                type: "dog",
+                name: "Daffodil"
+            }
+        }
+    };
+    describe("OWC sur un type de test", function () {
+
+        it("Test simple avec setter", function () {
+            var owc = new OWC();
+            owc.setData(dataTest);
+            owc.setVersion(1.0);
+            owc.setTemplate("test");
+            var result = owc.build();
+            expect(result).to.eql({
+                person: {
+                    name: "Edgar"
+                },
+                pets: {
+                    type: "dog",
+                    name: "Daffodil"
+                }
+            });
+        });
+
+        it("Test simple avec options du constructeur", function () {
+            var owc = new OWC({
+                data: dataTest,
+                template: "test",
+                version: 1.0
+            });
+            var result = owc.build();
+            expect(result).to.eql({
+                person: {
+                    name: "Edgar"
+                },
+                pets: {
+                    type: "dog",
+                    name: "Daffodil"
+                }
+            });
+        });
+    });
+
+    describe("OWC sur un type de config 1.0", function () {
+        it("Test WMS", function () {
+            var owc = new OWC();
+            owc.setData(dataWmsConfig);
+            owc.setVersion(1.0);
+            owc.setTemplate("config");
+            var json = owc.build();
+            console.log(json);
+            expect(json).to.have.property("type", "FeatureCollection");
+            expect(json).to.have.property("properties");
+            expect(json).to.have.property("geometry");
+            expect(json.geometry).to.have.property("type", "Polygon");
+            expect(json.geometry).to.have.property("coordinates");
+            expect(json.geometry.coordinates).to.be.an("array");
+            expect(json).to.have.property("features");
+            expect(json.features).to.be.an("array");
+        });
+
+    });
+});


### PR DESCRIPTION
# Exemple d’implémentation de OWC Context avec les service WMS

Le développement consiste à faire une transformation de schema entre la source et OWC Context.

## Sources possible

* le service de recherche
* le datastore de cartes.gouv.fr
* la conf tech de geoportail-configuration

## Implémentation possible

* [ ] implémentation via la classe de service
```js
// appel via les services
 Gp.Services.getContext({
      data : [{
        name : "PLAN.IGN",
        service : "TMS",
      }],
      configuration : {
          type : "service", // ou service|json|object
          url : "[url du service de recherche]" // data: "file.json" ou data: {}
      },
      onSuccess : (response) => {}
      onFailure : (error) => {}
 });
```

 * [ ] implémentation direct avec la classe
 ```js
 // appel direct de la classe
 var owc = new OWC({
  // conf tech issue de geoportal-configuration
  data : {...},
  // nom du template de transformation
  template : "geoportal-configuration", 
  // version du template
  version : 1.0, 
 });
 owc.setVersion();
 owc.setData();
 owc.setTemplate();
 var context = owc.build();
```

## Mettre en place pour les _offering_
 
* [ ] WMS
* [ ] WMTS
* [ ] TMS
* [ ] WFS
* [ ] KML
* [ ] GPX
* [ ] GeoJSON


